### PR TITLE
fix: Markdown build

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ downstream resources via Conduit.
 version: 2.2
 pipelines:
   - id: example
-    type: source
     status: running
     connectors:
       - id: example
@@ -99,7 +98,6 @@ resource via Conduit.
 version: 2.2
 pipelines:
   - id: example
-    type: destination
     status: running
     connectors:
       - id: example

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The Box Destination takes a Conduit record and uploads it to the remote Box dire
 
 The Box destination connector uploads the records in 3 different ways.
 
-* For a file which is <= 4MB, it uploads the single record file using a single
+* For a file which is ≤ 4MB, it uploads the single record file using a single
 `POST /files/content`.
-* For a file which is >= 4MB and <= 20MB, it assembles the file in memory. Once
+* For a file which is ≥ 4MB and ≤ 20MB, it assembles the file in memory. Once
 the file is fully assembled, it uploads it using a single
 `POST /files/content` request.
 * For a file which is > 20MB, it uploads the file using chunk upload endpoint.
@@ -78,6 +78,7 @@ downstream resources via Conduit.
 version: 2.2
 pipelines:
   - id: example
+    type: source
     status: running
     connectors:
       - id: example
@@ -98,6 +99,7 @@ resource via Conduit.
 version: 2.2
 pipelines:
   - id: example
+    type: destination
     status: running
     connectors:
       - id: example
@@ -186,13 +188,3 @@ The release is done in two steps:
   change.
 - Tag the connector, which will kick off a release. This can be done
   with [tag.sh](/scripts/tag.sh).
-
-## Known Issues & Limitations
-
-- Known issue A
-- Limitation A
-
-## Planned work
-
-- [ ] Item A
-- [ ] Item B

--- a/connector.yaml
+++ b/connector.yaml
@@ -64,7 +64,7 @@ specification:
     You can store the access token in one of the following ways:
     - As a plain string in a configuration file
     - As an environment variable
-  version: v0.1.0
+  version: v0.1.1
   author: Meroxa, Inc.
   destination:
     parameters:

--- a/connector.yaml
+++ b/connector.yaml
@@ -11,9 +11,9 @@ specification:
 
     The Box destination connector uploads the records in 3 different ways.
 
-    * For a file which is <= 4MB, it uploads the single record file using a single
+    * For a file which is ≤ 4MB, it uploads the single record file using a single
     `POST /files/content`.
-    * For a file which is >= 4MB and <= 20MB, it assembles the file in memory. Once
+    * For a file which is ≥ 4MB and ≤ 20MB, it assembles the file in memory. Once
     the file is fully assembled, it uploads it using a single
     `POST /files/content` request.
     * For a file which is > 20MB, it uploads the file using chunk upload endpoint.


### PR DESCRIPTION
### Description

Fixes this error from this Conduit Site build: https://github.com/ConduitIO/conduit-site/pull/316

Error in the logs:

```
Error: MDX compilation failed for file "/Users/raulbarroso/code/conduitio/conduit-site/docs/1-using/5-connectors/7-list/15-box.mdx"
Cause: Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`
Details:
{
"column": 24,
"message": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
"line": 90,
"name": "90:24",
"place": {
"_bufferIndex": 21,
"_index": 0,
"line": 90,
"column": 24,
"offset": 3691
},
"reason": "Unexpected character `=` (U+003D) before name, expected a character that can start a name, such as a letter, `$`, or `_`",
"ruleId": "unexpected-character",
"source": "micromark-extension-mdx-jsx",
"url": "[https://github.com/micromark/micromark-extension-mdx-jsx#unexpected-character-at-expected-expect](https://github.com/micromark/micromark-extension-mdx-jsx#unexpected-character-at-expected-expect)”cd 
```

Tested with fixing manually these on conduit site and it works. This can be reproduced easily by going to the Conduit Site pull-request, and editing the box.md file and see how it runs locally.



### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-box/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.